### PR TITLE
[FIXED] Fixing the height of the translate button #84

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -66,8 +66,8 @@ body {
   border-radius: 5px; 
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
   position: fixed;
-  top: 650px; 
-  left: 20px;
+  top: 881px; 
+  left: 0px;
   z-index: 1000;
 
 }


### PR DESCRIPTION
# Related Issue
Fixing the height of the translate button #84 

## Fixes Issue:
- #84 

## Description:
Changed the top and left measurements of the google translate placement of top from 650px to 881px and left from 20px to 0px in order to bring it to the bottom corner of the page and along it with the chatbot and top button present on the right hand side of the screen. It is shown in the screenshots attached below and highlighted with a red box.

## Screenshots:
Before:
<img width="1912" alt="Screenshot 2024-10-19 at 3 59 12 PM" src="https://github.com/user-attachments/assets/6db64508-de17-484b-8c62-8524ab78e9fc">
After:
<img width="1912" alt="Screenshot 2024-10-19 at 4 11 51 PM" src="https://github.com/user-attachments/assets/f19222d5-132b-4be9-aa65-695e9e11a0be">
