### PR TITLE
#144 -Fix: Changed button to correctly reflect state during Autoplay

### DIFF
--- a/main/level_1/phishing_animated_video.html
+++ b/main/level_1/phishing_animated_video.html
@@ -289,7 +289,10 @@
             video.currentTime = pos * video.duration;
         });
 
-        video.play().catch(error => {
+        video.play().then(() => {
+            playPauseBtn.textContent = 'Pause'
+            console.log("Video is playing automatically.");
+        }).catch(error => {
             console.log("Auto-play prevented:", error);
         });
 

--- a/main/level_2/phishing_animated_video.html
+++ b/main/level_2/phishing_animated_video.html
@@ -297,7 +297,10 @@
         video.currentTime = pos * video.duration;
     });
 
-    video.play().catch(error => {
+    video.play().then(() => {
+        playPauseBtn.textContent = 'Pause'
+        console.log("Video is playing automatically.");
+    }).catch(error => {
         console.log("Auto-play prevented:", error);
     });
 

--- a/main/level_3/phishing_animated_video.html
+++ b/main/level_3/phishing_animated_video.html
@@ -308,7 +308,10 @@
             video.currentTime = pos * video.duration;
         });
 
-        video.play().catch(error => {
+        video.play().then(() => {
+            playPauseBtn.textContent = 'Pause'
+            console.log("Video is playing automatically.");
+        }).catch(error => {
             console.log("Auto-play prevented:", error);
         });
 


### PR DESCRIPTION
Fixes #144 

**Problem**
The button on videos did not accurately update to pause or play during Auto-plays. 

**Changes**
Changed it so that the Button now reads the state of the video when it auto-plays and updates itself accordingly.

**Contribution Checklist**
- [X] I have carefully read the instructions for contributing to the project.
- [X] My contributions align with the current project structure and conventions.
- [X] My Changes don't affect the project in a negative way
- [X] I understand that the maintainers will review my pull request and provide feedback if necessary.
